### PR TITLE
do not pass host and port to loop.create_connection when there's a sock

### DIFF
--- a/src/asynqp/__init__.py
+++ b/src/asynqp/__init__.py
@@ -35,8 +35,12 @@ def connect(host='localhost',
 
     loop = asyncio.get_event_loop() if loop is None else loop
 
+    if 'sock' not in kwargs:
+        kwargs['host'] = host
+        kwargs['port'] = port
+
     dispatcher = Dispatcher()
-    transport, protocol = yield from loop.create_connection(lambda: AMQP(dispatcher, loop), host=host, port=port, **kwargs)
+    transport, protocol = yield from loop.create_connection(lambda: AMQP(dispatcher, loop), **kwargs)
 
     connection = yield from open_connection(loop, protocol, dispatcher, ConnectionInfo(username, password, virtual_host))
     return connection


### PR DESCRIPTION
asyncio create_connection allows to pass a sock param with already open file descriptor number to use it instead of opening new connection to host/port.

It's raising an Exception: "host/port and sock can not be specified at the same time" when trying to pass sock as a keyword argument to asynqp.connect().

That's an easy way to allow both approaches work fine and be compliant with asyncio api.

Passing open socket descriptor is a common practice to restart an application without loosing any data from already open socket - it's used by gunicorn, uwsgi, nginx, etc.
