### PR TITLE
Added new exceptions and logic to allow reconnecting connections

### DIFF
--- a/src/asynqp/__init__.py
+++ b/src/asynqp/__init__.py
@@ -50,11 +50,11 @@ def connect(host='localhost',
     dispatcher = Dispatcher()
     try:
         transport, protocol = yield from loop.create_connection(lambda: AMQP(dispatcher, loop), **kwargs)
-    except (ConnectionRefusedError, OSError):
+    except (ConnectionRefusedError, OSError) as e:
         # Throw a single exception instead of two
         raise ConnectionRefusedError('Failed to connect - host: {} port: {}'
                                      ' username: {} password: {} virtual_host: {}'
-                                     .format(host, port, username, password, virtual_host))
+                                     .format(host, port, username, password, virtual_host)) from e
 
     connection = yield from open_connection(loop, transport, protocol, dispatcher, ConnectionInfo(username, password, virtual_host))
     return connection

--- a/src/asynqp/bases.py
+++ b/src/asynqp/bases.py
@@ -19,3 +19,6 @@ class FrameHandler(object):
             meth = getattr(self, 'handle_' + type(frame.payload).__name__)
 
         meth(frame)
+
+    def handle_ConnectionClosedPoisonPillFrame(self, frame):
+        self.synchroniser.notify_connection_closed()

--- a/src/asynqp/exceptions.py
+++ b/src/asynqp/exceptions.py
@@ -1,11 +1,28 @@
 __all__ = [
     "AMQPError",
+    "ConnectionClosedError",
+    "ConnectionLostError",
     "UndeliverableMessage",
     "Deleted"
 ]
 
 
 class AMQPError(IOError):
+    pass
+
+
+class ConnectionClosedError(ConnectionError):
+    '''
+    Connection was closed normally by either the amqp server
+    or the client.
+    '''
+    pass
+
+
+class ConnectionLostError(ConnectionClosedError):
+    '''
+    Connection was closed unexpectedly
+    '''
     pass
 
 

--- a/src/asynqp/frames.py
+++ b/src/asynqp/frames.py
@@ -64,3 +64,11 @@ class HeartbeatFrame(Frame):
 
     def __init__(self):
         pass
+
+
+class ConnectionClosedPoisonPillFrame(Frame):
+    channel_id = 0
+    payload = b''
+
+    def __init__(self):
+        pass

--- a/src/asynqp/protocol.py
+++ b/src/asynqp/protocol.py
@@ -52,7 +52,7 @@ class AMQP(asyncio.Protocol):
         if exc is None:
             raise ConnectionClosedError('The connection was closed')
         else:
-            raise ConnectionLostError('The connection was unexpectedly lost')
+            raise ConnectionLostError('The connection was unexpectedly lost') from exc
 
     def _send_connection_closed_poison_pill(self):
         frame = frames.ConnectionClosedPoisonPillFrame()

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,6 @@
+import asyncio
+from .util import testing_exception_handler
+
+
+loop = asyncio.get_event_loop()
+loop.set_exception_handler(testing_exception_handler)

--- a/test/channel_tests.py
+++ b/test/channel_tests.py
@@ -174,7 +174,7 @@ class WhenBasicReturnArrivesAndIHaveNotDefinedAHandler(OpenChannelContext):
         assert self.exception.args == (self.expected_message,)
 
     def cleanup_the_exception_handler(self):
-        self.loop.set_exception_handler(None)
+        self.loop.set_exception_handler(util.testing_exception_handler)
 
 
 # test that the call to handler.ready() happens at the correct time
@@ -195,7 +195,7 @@ class WhenBasicReturnArrivesAfterThrowingTheExceptionOnce(OpenChannelContext):
         assert self.exception is not None
 
     def cleanup_the_exception_handler(self):
-        self.loop.set_exception_handler(None)
+        self.loop.set_exception_handler(util.testing_exception_handler)
 
     def return_msg(self):
         method = spec.BasicReturn(123, "you messed up", "the.exchange", "the.routing.key")

--- a/test/integration_tests.py
+++ b/test/integration_tests.py
@@ -2,6 +2,7 @@ import asyncio
 import asynqp
 import socket
 import contexts
+from .util import testing_exception_handler
 
 
 class ConnectionContext:
@@ -216,3 +217,115 @@ class WhenBasicCancelIsInterleavedWithAnotherMethod(BoundQueueContext):
 
     def it_should_not_throw(self):
         assert self.exception is None
+
+
+class WhenAConnectionIsClosed:
+    def given_an_exception_handler_and_connection(self):
+        self.loop = asyncio.get_event_loop()
+        self.connection_closed_error_raised = False
+        self.loop.set_exception_handler(self.exception_handler)
+        self.connection = self.loop.run_until_complete(asynqp.connect())
+
+    def exception_handler(self, loop, context):
+        exception = context.get('exception')
+        if type(exception) is asynqp.exceptions.ConnectionClosedError:
+            self.connection_closed_error_raised = True
+        else:
+            self.loop.default_exception_handler(context)
+
+    def when_the_connection_is_closed(self):
+        self.loop.run_until_complete(self.connection.close())
+
+    def it_should_raise_a_connection_closed_error(self):
+        assert self.connection_closed_error_raised is True
+
+    def cleanup(self):
+        self.loop.set_exception_handler(testing_exception_handler)
+
+
+class WhenAConnectionIsLost:
+    def given_an_exception_handler_and_connection(self):
+        self.loop = asyncio.get_event_loop()
+        self.connection_lost_error_raised = False
+        self.loop.set_exception_handler(self.exception_handler)
+        self.connection = self.loop.run_until_complete(asynqp.connect())
+
+    def exception_handler(self, loop, context):
+        exception = context.get('exception')
+        if type(exception) is asynqp.exceptions.ConnectionLostError:
+            self.connection_lost_error_raised = True
+            self.loop.stop()
+        else:
+            self.loop.default_exception_handler(context)
+
+    def when_the_heartbeat_times_out(self):
+        self.loop.call_soon(self.connection
+                            .protocol
+                            .heartbeat_monitor.heartbeat_timed_out)
+        self.loop.run_forever()
+
+    def it_should_raise_a_connection_closed_error(self):
+        assert self.connection_lost_error_raised is True
+
+    def cleanup(self):
+        self.loop.set_exception_handler(testing_exception_handler)
+
+
+class WhenAConnectionIsClosedCloseConnection:
+    def given_a_connection(self):
+        self.loop = asyncio.get_event_loop()
+        self.connection = self.loop.run_until_complete(asynqp.connect())
+
+    def when_connection_is_closed(self):
+        self.connection.transport.close()
+
+    def it_should_not_hang(self):
+        self.loop.run_until_complete(asyncio.wait_for(self.connection.close(), 0.2))
+
+
+class WhenAConnectionIsClosedCloseChannel:
+    def given_a_channel(self):
+        self.loop = asyncio.get_event_loop()
+        self.connection = self.loop.run_until_complete(asynqp.connect())
+        self.channel = self.loop.run_until_complete(self.connection.open_channel())
+
+    def when_connection_is_closed(self):
+        self.connection.transport.close()
+
+    def it_should_not_hang(self):
+        self.loop.run_until_complete(asyncio.wait_for(self.channel.close(), 0.2))
+
+
+class WhenAConnectionIsClosedCancelConsuming:
+    def given_a_consumer(self):
+        asynqp.routing._TEST = True
+        self.loop = asyncio.get_event_loop()
+        self.connection = self.loop.run_until_complete(asynqp.connect())
+        self.channel = self.loop.run_until_complete(self.connection.open_channel())
+        self.exchange = self.loop.run_until_complete(
+            self.channel.declare_exchange(name='name',
+                                          type='direct',
+                                          durable=False,
+                                          auto_delete=True))
+
+        self.queue = self.loop.run_until_complete(
+            self.channel.declare_queue(name='',
+                                       durable=False,
+                                       exclusive=True,
+                                       auto_delete=True))
+
+        self.loop.run_until_complete(self.queue.bind(self.exchange,
+                                                     'name'))
+
+        self.consumer = self.loop.run_until_complete(
+            self.queue.consume(lambda x: x, exclusive=True)
+        )
+
+    def when_connection_is_closed(self):
+        self.connection.transport.close()
+
+    def it_should_not_hang(self):
+        self.loop.run_until_complete(asyncio.wait_for(self.consumer.cancel(), 0.2))
+
+    def cleanup(self):
+        asynqp.routing._TEST = False

--- a/test/queue_tests.py
+++ b/test/queue_tests.py
@@ -5,6 +5,7 @@ from asynqp import message
 from asynqp import frames
 from asynqp import spec
 from .base_contexts import OpenChannelContext, QueueContext, ExchangeContext, BoundQueueContext, ConsumerContext
+from .util import testing_exception_handler
 
 
 class WhenDeclaringAQueue(OpenChannelContext):
@@ -243,7 +244,7 @@ class WhenAConsumerThrowsAnExceptionAndAnotherMessageArrives(ConsumerContext):
         self.tick()
 
     def cleanup_the_exception_handler(self):
-        self.loop.set_exception_handler(None)
+        self.loop.set_exception_handler(testing_exception_handler)
 
 
 class WhenICancelAConsumer(ConsumerContext):

--- a/test/util.py
+++ b/test/util.py
@@ -3,6 +3,19 @@ from contextlib import contextmanager
 from unittest import mock
 import asynqp.frames
 from asynqp import protocol
+from asynqp.exceptions import ConnectionClosedError
+
+
+def testing_exception_handler(loop, context):
+    '''
+    Hides the expected ``ConnectionClosedErrors`` and
+    ``ConnectionLostErros`` during tests
+    '''
+    exception = context.get('exception')
+    if exception and isinstance(exception, ConnectionClosedError):
+        pass
+    else:
+        loop.default_exception_handler(context)
 
 
 class MockServer(object):


### PR DESCRIPTION
Added ConnectionClosedError and ConnectionLostError.
ConnectionClosedError is raised when the connection is closed normally,
ConnectionLostError is raised when the connection is lost unexpectedly.
cleanup
Send poison pill when the connection is closed so that cleanup methods
(Channel.close, Connection.close, Consumer.cancel) do not block waiting
for a message from the server on a closed connection.
Fixes from experience with an actual example script
consistently handle setting futures inside syncronizer when poison pill
is swallowed