### PR TITLE
Stop squashing OsError into ConnectionRefusedError when connecting

### DIFF
--- a/src/asynqp/__init__.py
+++ b/src/asynqp/__init__.py
@@ -48,13 +48,7 @@ def connect(host='localhost',
         kwargs['port'] = port
 
     dispatcher = Dispatcher()
-    try:
-        transport, protocol = yield from loop.create_connection(lambda: AMQP(dispatcher, loop), **kwargs)
-    except (ConnectionRefusedError, OSError) as e:
-        # Throw a single exception instead of two
-        raise ConnectionRefusedError('Failed to connect - host: {} port: {}'
-                                     ' username: {} password: {} virtual_host: {}'
-                                     .format(host, port, username, password, virtual_host)) from e
+    transport, protocol = yield from loop.create_connection(lambda: AMQP(dispatcher, loop), **kwargs)
 
     connection = yield from open_connection(loop, transport, protocol, dispatcher, ConnectionInfo(username, password, virtual_host))
     return connection


### PR DESCRIPTION
I've seen the light, you are absolutely correct. I didn't see your comment earlier, it was hidden as I had already modified that section of code.

This should bring things back in order, should have done it earlier, sorry for the extra work.



>Yes, it depends. For that use case of simply retrying a connection for any type of failure, I agree that it's more convenient to catch one exception than two. However some clients may want to behave differently depending on the type of error.

>For example, if the server actively refuses a connection it may be because Rabbit isn't running; whereas if the socket can't be opened it more likely indicates a local failure. By shoving both errors into one exception, we're ruling out the possibility of clients distinguishing the two types of failure; plus it's hard to go back to two exceptions because of backwards compatibility.

>The from e trick does partially address this loss of information, but it's more designed for debugging than error handling.

>If a client really does want to retry on all failures, you can just catch any type of exception (except Exception as e).



