### PR TITLE
Signed/unsigned serialization and expanded table serialization

### DIFF
--- a/src/asynqp/amqptypes.py
+++ b/src/asynqp/amqptypes.py
@@ -1,13 +1,6 @@
 import datetime
 from . import serialisation
 
-
-MAX_OCTET = 0xFF
-MAX_SHORT = 0xFFFF
-MAX_LONG = 0xFFFFFFFF
-MAX_LONG_LONG = 0xFFFFFFFFFFFFFFFF
-
-
 class Bit(object):
     def __init__(self, value):
         if isinstance(value, type(self)):
@@ -33,8 +26,10 @@ class Bit(object):
 
 
 class Octet(int):
+    MIN = 0
+    MAX = (1<<8)-1
     def __new__(cls, value):
-        if not (0 <= value <= MAX_OCTET):
+        if not (Octet.MIN <= value <= Octet.MAX):
             raise TypeError('Could not construct an Octet from value {}'.format(value))
         return super().__new__(cls, value)
 
@@ -47,8 +42,10 @@ class Octet(int):
 
 
 class Short(int):
+    MIN = -(1<<15)
+    MAX = (1<<15)-1
     def __new__(cls, value):
-        if not (0 <= value <= MAX_SHORT):
+        if not (Short.MIN <= value <= Short.MAX):
             raise TypeError('Could not construct a Short from value {}'.format(value))
         return super().__new__(cls, value)
 
@@ -60,9 +57,26 @@ class Short(int):
         return cls(serialisation.read_short(stream))
 
 
-class Long(int):
+class UnsignedShort(int):
+    MIN = 0
+    MAX = (1<<16)-1
     def __new__(cls, value):
-        if not (0 <= value <= MAX_LONG):
+        if not (UnsignedShort.MIN <= value <= UnsignedShort.MAX):
+            raise TypeError('Could not construct an UnsignedShort from value {}'.format(value))
+        return super().__new__(cls, value)
+
+    def write(self, stream):
+        stream.write(serialisation.pack_unsigned_short(self))
+
+    @classmethod
+    def read(cls, stream):
+        return cls(serialisation.read_unsigned_short(stream))
+
+class Long(int):
+    MIN = -(1<<31)
+    MAX = (1<<31)-1
+    def __new__(cls, value):
+        if not (Long.MIN <= value <= Long.MAX):
             raise TypeError('Could not construct a Long from value {}'.format(value))
         return super().__new__(cls, value)
 
@@ -73,10 +87,28 @@ class Long(int):
     def read(cls, stream):
         return cls(serialisation.read_long(stream))
 
+class UnsignedLong(int):
+    MIN = 0
+    MAX = (1<<32)-1
+
+    def __new__(cls, value):
+        if not (UnsignedLong.MIN <= value <= UnsignedLong.MAX):
+            raise TypeError('Could not construct a UnsignedLong from value {}'.format(value))
+        return super().__new__(cls, value)
+
+    def write(self, stream):
+        stream.write(serialisation.pack_unsigned_long(self))
+
+    @classmethod
+    def read(cls, stream):
+        return cls(serialisation.read_unsigned_long(stream))
 
 class LongLong(int):
+    MIN = -(1<<63)
+    MAX = (1<<63)-1
+
     def __new__(cls, value):
-        if not (0 <= value <= MAX_LONG_LONG):
+        if not (LongLong.MIN <= value <= LongLong.MAX):
             raise TypeError('Could not construct a LongLong from value {}'.format(value))
         return super().__new__(cls, value)
 
@@ -87,10 +119,26 @@ class LongLong(int):
     def read(cls, stream):
         return cls(serialisation.read_long_long(stream))
 
+class UnsignedLongLong(int):
+    MIN = 0
+    MAX = (1<<64)-1
+
+    def __new__(cls, value):
+        if not (UnsignedLongLong.MIN <= value <= UnsignedLongLong.MAX):
+            raise TypeError('Could not construct a UnsignedLongLong from value {}'.format(value))
+        return super().__new__(cls, value)
+
+    def write(self, stream):
+        stream.write(serialisation.pack_unsigned_long_long(self))
+
+    @classmethod
+    def read(cls, stream):
+        return cls(serialisation.read_unsigned_long_long(stream))
+
 
 class ShortStr(str):
     def __new__(cls, value):
-        if len(value) > MAX_OCTET:
+        if len(value) > Octet.MAX:
             raise TypeError('Could not construct a ShortStr from value {}'.format(value))
         return super().__new__(cls, value)
 
@@ -107,7 +155,7 @@ class ShortStr(str):
 
 class LongStr(str):
     def __new__(cls, value):
-        if len(value) > MAX_LONG:
+        if len(value) > UnsignedLong.MAX:
             raise TypeError('Could not construct a LongStr from value {}'.format(value))
         return super().__new__(cls, value)
 
@@ -154,8 +202,11 @@ FIELD_TYPES = {
     'bit': Bit,
     'octet': Octet,
     'short': Short,
+    'unsignedshort': UnsignedShort,
     'long': Long,
+    'unsignedlong': UnsignedLong,
     'longlong': LongLong,
+    'unsignedlonglong': UnsignedLongLong,
     'table': Table,
     'longstr': LongStr,
     'shortstr': ShortStr,

--- a/src/asynqp/amqptypes.py
+++ b/src/asynqp/amqptypes.py
@@ -1,6 +1,7 @@
 import datetime
 from . import serialisation
 
+
 class Bit(object):
     def __init__(self, value):
         if isinstance(value, type(self)):
@@ -27,7 +28,8 @@ class Bit(object):
 
 class Octet(int):
     MIN = 0
-    MAX = (1<<8)-1
+    MAX = (1 << 8) - 1
+
     def __new__(cls, value):
         if not (Octet.MIN <= value <= Octet.MAX):
             raise TypeError('Could not construct an Octet from value {}'.format(value))
@@ -42,8 +44,9 @@ class Octet(int):
 
 
 class Short(int):
-    MIN = -(1<<15)
-    MAX = (1<<15)-1
+    MIN = -(1 << 15)
+    MAX = (1 << 15) - 1
+
     def __new__(cls, value):
         if not (Short.MIN <= value <= Short.MAX):
             raise TypeError('Could not construct a Short from value {}'.format(value))
@@ -59,7 +62,8 @@ class Short(int):
 
 class UnsignedShort(int):
     MIN = 0
-    MAX = (1<<16)-1
+    MAX = (1 << 16) - 1
+
     def __new__(cls, value):
         if not (UnsignedShort.MIN <= value <= UnsignedShort.MAX):
             raise TypeError('Could not construct an UnsignedShort from value {}'.format(value))
@@ -72,9 +76,11 @@ class UnsignedShort(int):
     def read(cls, stream):
         return cls(serialisation.read_unsigned_short(stream))
 
+
 class Long(int):
-    MIN = -(1<<31)
-    MAX = (1<<31)-1
+    MIN = -(1 << 31)
+    MAX = (1 << 31) - 1
+
     def __new__(cls, value):
         if not (Long.MIN <= value <= Long.MAX):
             raise TypeError('Could not construct a Long from value {}'.format(value))
@@ -87,9 +93,10 @@ class Long(int):
     def read(cls, stream):
         return cls(serialisation.read_long(stream))
 
+
 class UnsignedLong(int):
     MIN = 0
-    MAX = (1<<32)-1
+    MAX = (1 << 32) - 1
 
     def __new__(cls, value):
         if not (UnsignedLong.MIN <= value <= UnsignedLong.MAX):
@@ -103,9 +110,10 @@ class UnsignedLong(int):
     def read(cls, stream):
         return cls(serialisation.read_unsigned_long(stream))
 
+
 class LongLong(int):
-    MIN = -(1<<63)
-    MAX = (1<<63)-1
+    MIN = -(1 << 63)
+    MAX = (1 << 63) - 1
 
     def __new__(cls, value):
         if not (LongLong.MIN <= value <= LongLong.MAX):
@@ -119,9 +127,10 @@ class LongLong(int):
     def read(cls, stream):
         return cls(serialisation.read_long_long(stream))
 
+
 class UnsignedLongLong(int):
     MIN = 0
-    MAX = (1<<64)-1
+    MAX = (1 << 64) - 1
 
     def __new__(cls, value):
         if not (UnsignedLongLong.MIN <= value <= UnsignedLongLong.MAX):

--- a/src/asynqp/message.py
+++ b/src/asynqp/message.py
@@ -180,9 +180,9 @@ class ContentHeaderPayload(object):
                 and self.properties == other.properties)
 
     def write(self, stream):
-        stream.write(serialisation.pack_short(self.class_id))
-        stream.write(serialisation.pack_short(0))  # weight
-        stream.write(serialisation.pack_long_long(self.body_length))
+        stream.write(serialisation.pack_unsigned_short(self.class_id))
+        stream.write(serialisation.pack_unsigned_short(0))  # weight
+        stream.write(serialisation.pack_unsigned_long_long(self.body_length))
 
         bytesio = BytesIO()
 
@@ -195,17 +195,17 @@ class ContentHeaderPayload(object):
                 val.write(bytesio)
             bitshift -= 1
 
-        stream.write(serialisation.pack_short(property_flags))
+        stream.write(serialisation.pack_unsigned_short(property_flags))
         stream.write(bytesio.getvalue())
 
     @classmethod
     def read(cls, raw):
         bytesio = BytesIO(raw)
-        class_id = serialisation.read_short(bytesio)
-        weight = serialisation.read_short(bytesio)
+        class_id = serialisation.read_unsigned_short(bytesio)
+        weight = serialisation.read_unsigned_short(bytesio)
         assert weight == 0
-        body_length = serialisation.read_long_long(bytesio)
-        property_flags_short = serialisation.read_short(bytesio)
+        body_length = serialisation.read_unsigned_long_long(bytesio)
+        property_flags_short = serialisation.read_unsigned_short(bytesio)
 
         properties = []
         for amqptype, flag in zip(Message.property_types.values(), bin(property_flags_short)[2:]):

--- a/src/asynqp/serialisation.py
+++ b/src/asynqp/serialisation.py
@@ -27,15 +27,25 @@ def read_octet(stream):
 def read_short(stream):
     return _read_short(stream)[0]
 
+@rethrow_as(struct.error, AMQPError('failed to read an unsigned short'))
+def read_unsigned_short(stream):
+    return _read_unsigned_short(stream)[0]
 
 @rethrow_as(struct.error, AMQPError('failed to read a long'))
 def read_long(stream):
     return _read_long(stream)[0]
 
+@rethrow_as(struct.error, AMQPError('failed to read an unsigned long'))
+def read_unsigned_long(stream):
+    return _read_unsigned_long(stream)[0]
 
-@rethrow_as(struct.error, AMQPError('failed to read a long'))
+@rethrow_as(struct.error, AMQPError('failed to read a long long'))
 def read_long_long(stream):
     return _read_long_long(stream)[0]
+
+@rethrow_as(struct.error, AMQPError('failed to read an unsigned long long'))
+def read_unsigned_long_long(stream):
+    return _read_unsigned_long_long(stream)[0]
 
 
 @rethrow_as(struct.error, AMQPError('failed to read a short string'))
@@ -72,7 +82,13 @@ def _read_table(stream):
         b't': _read_bool,
         b's': _read_short_string,
         b'S': _read_long_string,
-        b'F': _read_table
+        b'F': _read_table,
+        b'u': _read_unsigned_short,
+        b'U': _read_short,
+        b'i': _read_unsigned_long,
+        b'I': _read_long,
+        b'l': _read_unsigned_long_long,
+        b'L': _read_long_long,
     }
 
     consumed = 0
@@ -103,7 +119,7 @@ def _read_short_string(stream):
 
 
 def _read_long_string(stream):
-    str_length, x = _read_long(stream)
+    str_length, x = _read_unsigned_long(stream)
     bytestring = stream.read(str_length)
     if len(bytestring) != str_length:
         raise AMQPError("Long string had incorrect length")
@@ -121,16 +137,29 @@ def _read_bool(stream):
 
 
 def _read_short(stream):
+    x, = struct.unpack('!h', stream.read(2))
+    return x, 2
+
+def _read_unsigned_short(stream):
     x, = struct.unpack('!H', stream.read(2))
     return x, 2
 
 
 def _read_long(stream):
+    x, = struct.unpack('!l', stream.read(4))
+    return x, 4
+
+def _read_unsigned_long(stream):
     x, = struct.unpack('!L', stream.read(4))
     return x, 4
 
 
 def _read_long_long(stream):
+    x, = struct.unpack('!q', stream.read(8))
+    return x, 8
+
+
+def _read_unsigned_long_long(stream):
     x, = struct.unpack('!Q', stream.read(8))
     return x, 8
 
@@ -152,11 +181,42 @@ def pack_long_string(string):
 def pack_table(d):
     bytes = b''
     for key, value in d.items():
-        if not isinstance(value, str):
-            raise NotImplementedError()
         bytes += pack_short_string(key)
-        bytes += b'S'  # todo: more values
-        bytes += pack_long_string(value)
+        # todo: more values
+        if isinstance(value, dict):
+            bytes += b'F'
+            bytes += pack_table(value)
+        elif isinstance(value, str):
+            bytes += b'S'
+            bytes += pack_long_string(value)
+        elif isinstance(value, int):
+            if value < 0:
+                if value.bit_length() < 16:
+                    bytes += b'U'
+                    bytes += pack_short(value)
+                elif value.bit_length() < 32:
+                    bytes += b'I'
+                    bytes += pack_long(value)
+                else:
+                    bytes += b'L'
+                    bytes += pack_long_long(value)
+            else:
+                if value.bit_length() <= 16:
+                    bytes += b'u'
+                    bytes += pack_unsigned_short(value)
+                elif value.bit_length() <= 32:
+                    bytes += b'i'
+                    bytes += pack_unsigned_long(value)
+                else:
+                    bytes += b'l'
+                    bytes += pack_unsigned_long_long(value)
+
+        elif isinstance(value, bool):
+            bytes += b't'
+            bytes += pack_bool(value)
+        else:
+            raise NotImplementedError()
+
     val = pack_long(len(bytes)) + bytes
     return val
 
@@ -164,18 +224,28 @@ def pack_table(d):
 def pack_octet(number):
     return struct.pack('!B', number)
 
-
 def pack_short(number):
+    return struct.pack('!h', number)
+
+def pack_unsigned_short(number):
     return struct.pack('!H', number)
 
-
 def pack_long(number):
+    return struct.pack('!l', number)
+
+def pack_unsigned_long(number):
     return struct.pack('!L', number)
 
 
 def pack_long_long(number):
+    return struct.pack('!q', number)
+
+def pack_unsigned_long_long(number):
     return struct.pack('!Q', number)
 
+
+def pack_bool(b):
+    return struct.pack('!?', b)
 
 def pack_bools(*bs):
     tot = 0

--- a/src/asynqp/serialisation.py
+++ b/src/asynqp/serialisation.py
@@ -27,21 +27,26 @@ def read_octet(stream):
 def read_short(stream):
     return _read_short(stream)[0]
 
+
 @rethrow_as(struct.error, AMQPError('failed to read an unsigned short'))
 def read_unsigned_short(stream):
     return _read_unsigned_short(stream)[0]
+
 
 @rethrow_as(struct.error, AMQPError('failed to read a long'))
 def read_long(stream):
     return _read_long(stream)[0]
 
+
 @rethrow_as(struct.error, AMQPError('failed to read an unsigned long'))
 def read_unsigned_long(stream):
     return _read_unsigned_long(stream)[0]
 
+
 @rethrow_as(struct.error, AMQPError('failed to read a long long'))
 def read_long_long(stream):
     return _read_long_long(stream)[0]
+
 
 @rethrow_as(struct.error, AMQPError('failed to read an unsigned long long'))
 def read_unsigned_long_long(stream):
@@ -140,6 +145,7 @@ def _read_short(stream):
     x, = struct.unpack('!h', stream.read(2))
     return x, 2
 
+
 def _read_unsigned_short(stream):
     x, = struct.unpack('!H', stream.read(2))
     return x, 2
@@ -148,6 +154,7 @@ def _read_unsigned_short(stream):
 def _read_long(stream):
     x, = struct.unpack('!l', stream.read(4))
     return x, 4
+
 
 def _read_unsigned_long(stream):
     x, = struct.unpack('!L', stream.read(4))
@@ -224,14 +231,18 @@ def pack_table(d):
 def pack_octet(number):
     return struct.pack('!B', number)
 
+
 def pack_short(number):
     return struct.pack('!h', number)
+
 
 def pack_unsigned_short(number):
     return struct.pack('!H', number)
 
+
 def pack_long(number):
     return struct.pack('!l', number)
+
 
 def pack_unsigned_long(number):
     return struct.pack('!L', number)
@@ -240,12 +251,14 @@ def pack_unsigned_long(number):
 def pack_long_long(number):
     return struct.pack('!q', number)
 
+
 def pack_unsigned_long_long(number):
     return struct.pack('!Q', number)
 
 
 def pack_bool(b):
     return struct.pack('!?', b)
+
 
 def pack_bools(*bs):
     tot = 0

--- a/test/serialisation_tests.py
+++ b/test/serialisation_tests.py
@@ -17,6 +17,23 @@ class WhenParsingATable:
     def it_should_return_the_table(self, bytes, expected):
         assert self.result == expected
 
+class WhenPackingAndUnpackingATable:
+    @classmethod
+    def examples_of_tables(cls):
+        for encoded, table in WhenParsingATable.examples_of_tables():
+            yield table
+        yield { 'a': (1<<16), 'b': (1<<15) }
+        yield { 'c': 65535, 'd': -65535 }
+        yield { 'e': -65536 }
+        yield { 'f': -(1<<63), 'g': ((1<<64)-1)}
+        yield { 'f': (1<<32), 'g': (1<<63)}
+
+    def because_we_pack_and_unpack_the_table(self, table):
+        self.result = serialisation.read_table(BytesIO(serialisation.pack_table(table)))
+
+    def it_should_return_the_table(self, table):
+        assert self.result == table
+
 
 class WhenParsingABadTable:
     @classmethod

--- a/test/serialisation_tests.py
+++ b/test/serialisation_tests.py
@@ -17,16 +17,17 @@ class WhenParsingATable:
     def it_should_return_the_table(self, bytes, expected):
         assert self.result == expected
 
+
 class WhenPackingAndUnpackingATable:
     @classmethod
     def examples_of_tables(cls):
         for encoded, table in WhenParsingATable.examples_of_tables():
             yield table
-        yield { 'a': (1<<16), 'b': (1<<15) }
-        yield { 'c': 65535, 'd': -65535 }
-        yield { 'e': -65536 }
-        yield { 'f': -(1<<63), 'g': ((1<<64)-1)}
-        yield { 'f': (1<<32), 'g': (1<<63)}
+        yield {'a': (1 << 16), 'b': (1 << 15)}
+        yield {'c': 65535, 'd': -65535}
+        yield {'e': -65536}
+        yield {'f': -(1 << 63), 'g': ((1 << 64) - 1)}
+        yield {'f': (1 << 32), 'g': (1 << 63)}
 
     def because_we_pack_and_unpack_the_table(self, table):
         self.result = serialisation.read_table(BytesIO(serialisation.pack_table(table)))


### PR DESCRIPTION
Explicitly use unsigned serialization for unsigned integers.
Expand table serialization for more types (integers, bool, dict),
