### PR TITLE
Improved RabbitMq Compatibility

### DIFF
--- a/src/asynqp/amqptypes.py
+++ b/src/asynqp/amqptypes.py
@@ -196,7 +196,7 @@ class Timestamp(datetime.datetime):
         raise TypeError("Could not construct a timestamp from value {}".format(value))
 
     def __eq__(self, other):
-        return abs(self - other) < datetime.timedelta(seconds=1)
+        return abs(self - other) < datetime.timedelta(milliseconds=1)
 
     def write(self, stream):
         stamp = int(self.timestamp())


### PR DESCRIPTION
… to rabbitmq and possibly qpid

Apparently, the standard defined incompatible type-codes the pre-existing Qpid/Rabbit extensions,
and at least rabbitmq kept them instead.
Documentation: https://www.rabbitmq.com/amqp-0-9-1-errata.html#section_3
Code: https://github.com/rabbitmq/rabbitmq-server/blob/rabbitmq_v3_5_3/src/rabbit_binary_parser.erl#L41