### PR TITLE
Pass custom attribute tables

### DIFF
--- a/src/asynqp/serialisation.py
+++ b/src/asynqp/serialisation.py
@@ -92,7 +92,6 @@ def read_bools(byte, number_of_bools):
 def read_timestamp(stream):
     return _read_timestamp(stream)[0]
 
-
 def qpid_rabbit_mq_table():
     # TODO: fix amqp 0.9.1 compatibility
     # TODO: Add missing types

--- a/src/asynqp/serialisation.py
+++ b/src/asynqp/serialisation.py
@@ -92,6 +92,7 @@ def read_bools(byte, number_of_bools):
 def read_timestamp(stream):
     return _read_timestamp(stream)[0]
 
+
 def qpid_rabbit_mq_table():
     # TODO: fix amqp 0.9.1 compatibility
     # TODO: Add missing types


### PR DESCRIPTION
The argument tables can be used for various extensions on rabbitmq.

As described in #26, due to some incompatibilities, it only works with a change to the serialiser code table (or a restriction to a subset).

The pull request includes 9c826d1from pull request #26, but that change could be replaced with an alternative implementation of serialiser.
