### PR TITLE
Added explicit loop passing to all components from connection.

### DIFF
--- a/src/asynqp/channel.py
+++ b/src/asynqp/channel.py
@@ -28,7 +28,10 @@ class Channel(object):
 
         the numerical ID of the channel
     """
-    def __init__(self, id, synchroniser, sender, basic_return_consumer, queue_factory, reader):
+    def __init__(self, id, synchroniser, sender, basic_return_consumer, queue_factory, reader, *, loop=None):
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self._loop = loop
         self.id = id
         self.synchroniser = synchroniser
         self.sender = sender
@@ -158,19 +161,22 @@ class ChannelFactory(object):
     def open(self):
         self.next_channel_id += 1
         channel_id = self.next_channel_id
-        synchroniser = routing.Synchroniser()
+        synchroniser = routing.Synchroniser(loop=self.loop)
 
         sender = ChannelMethodSender(channel_id, self.protocol, self.connection_info)
-        basic_return_consumer = BasicReturnConsumer()
+        basic_return_consumer = BasicReturnConsumer(loop=self.loop)
         consumers = queue.Consumers(self.loop)
         consumers.add_consumer(basic_return_consumer)
 
-        handler = ChannelActor(consumers, synchroniser, sender)
-        reader, writer = routing.create_reader_and_writer(handler)
+        handler = ChannelActor(consumers, synchroniser, sender, loop=self.loop)
+        reader, writer = routing.create_reader_and_writer(handler, loop=self.loop)
         handler.message_receiver = MessageReceiver(synchroniser, sender, consumers, reader)
 
-        queue_factory = queue.QueueFactory(sender, synchroniser, reader, consumers)
-        channel = Channel(channel_id, synchroniser, sender, basic_return_consumer, queue_factory, reader)
+        queue_factory = queue.QueueFactory(
+            sender, synchroniser, reader, consumers, loop=self.loop)
+        channel = Channel(
+            channel_id, synchroniser, sender, basic_return_consumer,
+            queue_factory, reader, loop=self.loop)
 
         self.dispatcher.add_writer(channel_id, writer)
         try:
@@ -229,7 +235,8 @@ class ChannelActor(routing.Actor):
         self.synchroniser.notify(spec.BasicGetEmpty, False)
 
     def handle_BasicGetOK(self, frame):
-        asyncio.async(self.message_receiver.receive_getOK(frame))
+        assert self.message_receiver is not None, "message_receiver not set"
+        asyncio.async(self.message_receiver.receive_getOK(frame), loop=self._loop)
 
     def handle_BasicConsumeOK(self, frame):
         self.synchroniser.notify(spec.BasicConsumeOK, frame.payload.consumer_tag)
@@ -238,13 +245,16 @@ class ChannelActor(routing.Actor):
         self.synchroniser.notify(spec.BasicCancelOK)
 
     def handle_BasicDeliver(self, frame):
-        asyncio.async(self.message_receiver.receive_deliver(frame))
+        assert self.message_receiver is not None, "message_receiver not set"
+        asyncio.async(self.message_receiver.receive_deliver(frame), loop=self._loop)
 
     def handle_ContentHeaderFrame(self, frame):
-        asyncio.async(self.message_receiver.receive_header(frame))
+        assert self.message_receiver is not None, "message_receiver not set"
+        asyncio.async(self.message_receiver.receive_header(frame), loop=self._loop)
 
     def handle_ContentBodyFrame(self, frame):
-        asyncio.async(self.message_receiver.receive_body(frame))
+        assert self.message_receiver is not None, "message_receiver not set"
+        asyncio.async(self.message_receiver.receive_body(frame), loop=self._loop)
 
     def handle_ChannelClose(self, frame):
         self.sender.send_CloseOK()
@@ -258,7 +268,8 @@ class ChannelActor(routing.Actor):
         self.synchroniser.notify(spec.BasicQosOK)
 
     def handle_BasicReturn(self, frame):
-        asyncio.async(self.message_receiver.receive_return(frame))
+        assert self.message_receiver is not None, "message_receiver not set"
+        asyncio.async(self.message_receiver.receive_return(frame), loop=self._loop)
 
 
 class MessageReceiver(object):
@@ -411,9 +422,9 @@ class ChannelMethodSender(routing.Sender):
 class BasicReturnConsumer(object):
     tag = -1  # a 'real' tag is a string so there will never be a clash
 
-    def __init__(self):
+    def __init__(self, *, loop):
         self.callback = self.default_behaviour
-        self.cancelled_future = asyncio.Future()
+        self.cancelled_future = asyncio.Future(loop=loop)
 
     def set_callback(self, callback):
         if callback is None:

--- a/src/asynqp/channel.py
+++ b/src/asynqp/channel.py
@@ -28,9 +28,7 @@ class Channel(object):
 
         the numerical ID of the channel
     """
-    def __init__(self, id, synchroniser, sender, basic_return_consumer, queue_factory, reader, *, loop=None):
-        if loop is None:
-            loop = asyncio.get_event_loop()
+    def __init__(self, id, synchroniser, sender, basic_return_consumer, queue_factory, reader, *, loop):
         self._loop = loop
         self.id = id
         self.synchroniser = synchroniser

--- a/src/asynqp/connection.py
+++ b/src/asynqp/connection.py
@@ -32,7 +32,6 @@ class Connection(object):
         The :class:`~asyncio.Protocol` which is paired with the transport
     """
     def __init__(self, loop, transport, protocol, synchroniser, sender, dispatcher, connection_info):
-        self._loop = loop
         self.synchroniser = synchroniser
         self.sender = sender
         self.channel_factory = channel.ChannelFactory(loop, protocol, dispatcher, connection_info)

--- a/src/asynqp/queue.py
+++ b/src/asynqp/queue.py
@@ -37,9 +37,7 @@ class Queue(object):
 
         A dictionary of the extra arguments that were used to declare the queue.
     """
-    def __init__(self, reader, consumers, synchroniser, sender, name, durable, exclusive, auto_delete, arguments, *, loop=None):
-        if loop is None:
-            loop = asyncio.get_event_loop()
+    def __init__(self, reader, consumers, synchroniser, sender, name, durable, exclusive, auto_delete, arguments, *, loop):
         self._loop = loop
         self.reader = reader
         self.consumers = consumers
@@ -243,9 +241,7 @@ class Consumer(object):
 
         Boolean. True if the consumer has been successfully cancelled.
     """
-    def __init__(self, tag, callback, sender, synchroniser, reader, *, loop=None):
-        if loop is None:
-            loop = asyncio.get_event_loop()
+    def __init__(self, tag, callback, sender, synchroniser, reader, *, loop):
         self._loop = loop
         self.tag = tag
         self.callback = callback
@@ -272,9 +268,7 @@ class Consumer(object):
 
 
 class QueueFactory(object):
-    def __init__(self, sender, synchroniser, reader, consumers, *, loop=None):
-        if loop is None:
-            loop = asyncio.get_event_loop()
+    def __init__(self, sender, synchroniser, reader, consumers, *, loop):
         self._loop = loop
         self.sender = sender
         self.synchroniser = synchroniser

--- a/src/asynqp/queue.py
+++ b/src/asynqp/queue.py
@@ -37,7 +37,10 @@ class Queue(object):
 
         A dictionary of the extra arguments that were used to declare the queue.
     """
-    def __init__(self, reader, consumers, synchroniser, sender, name, durable, exclusive, auto_delete, arguments):
+    def __init__(self, reader, consumers, synchroniser, sender, name, durable, exclusive, auto_delete, arguments, *, loop=None):
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self._loop = loop
         self.reader = reader
         self.consumers = consumers
         self.synchroniser = synchroniser
@@ -106,7 +109,9 @@ class Queue(object):
 
         self.sender.send_BasicConsume(self.name, no_local, no_ack, exclusive, arguments or {})
         tag = yield from self.synchroniser.await(spec.BasicConsumeOK)
-        consumer = Consumer(tag, callback, self.sender, self.synchroniser, self.reader)
+        consumer = Consumer(
+            tag, callback, self.sender, self.synchroniser, self.reader,
+            loop=self._loop)
         self.consumers.add_consumer(consumer)
         self.reader.ready()
         return consumer
@@ -238,14 +243,17 @@ class Consumer(object):
 
         Boolean. True if the consumer has been successfully cancelled.
     """
-    def __init__(self, tag, callback, sender, synchroniser, reader):
+    def __init__(self, tag, callback, sender, synchroniser, reader, *, loop=None):
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self._loop = loop
         self.tag = tag
         self.callback = callback
         self.sender = sender
         self.cancelled = False
         self.synchroniser = synchroniser
         self.reader = reader
-        self.cancelled_future = asyncio.Future()
+        self.cancelled_future = asyncio.Future(loop=self._loop)
 
     @asyncio.coroutine
     def cancel(self):
@@ -264,7 +272,10 @@ class Consumer(object):
 
 
 class QueueFactory(object):
-    def __init__(self, sender, synchroniser, reader, consumers):
+    def __init__(self, sender, synchroniser, reader, consumers, *, loop=None):
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self._loop = loop
         self.sender = sender
         self.synchroniser = synchroniser
         self.reader = reader
@@ -279,7 +290,9 @@ class QueueFactory(object):
 
         self.sender.send_QueueDeclare(name, durable, exclusive, auto_delete, arguments)
         name = yield from self.synchroniser.await(spec.QueueDeclareOK)
-        q = Queue(self.reader, self.consumers, self.synchroniser, self.sender, name, durable, exclusive, auto_delete, arguments)
+        q = Queue(self.reader, self.consumers, self.synchroniser, self.sender,
+                  name, durable, exclusive, auto_delete, arguments,
+                  loop=self._loop)
         self.reader.ready()
         return q
 

--- a/src/asynqp/routing.py
+++ b/src/asynqp/routing.py
@@ -116,9 +116,7 @@ def create_reader_and_writer(handler, *, loop):
 # When the frame does arrive, dispatch it to the handler and do nothing
 # until someone calls ready() again.
 class QueueReader(object):
-    def __init__(self, handler, q, *, loop=None):
-        if loop is None:
-            loop = asyncio.get_event_loop()
+    def __init__(self, handler, q, *, loop):
         self._loop = loop
         self.handler = handler
         self.q = q

--- a/src/asynqp/routing.py
+++ b/src/asynqp/routing.py
@@ -38,9 +38,7 @@ class Sender(object):
 
 
 class Actor(object):
-    def __init__(self, synchroniser, sender, *, loop=None):
-        if loop is None:
-            loop = asyncio.get_event_loop()
+    def __init__(self, synchroniser, sender, *, loop):
         self._loop = loop
         self.synchroniser = synchroniser
         self.sender = sender
@@ -65,9 +63,7 @@ class Synchroniser(object):
                              spec.ChannelCloseOK,  # Channel.close
                              spec.ConnectionCloseOK))  # Connection.close
 
-    def __init__(self, *, loop=None):
-        if loop is None:
-            loop = asyncio.get_event_loop()
+    def __init__(self, *, loop):
         self._loop = loop
         self._futures = OrderedManyToManyMap()
         self.connection_closed = False
@@ -109,9 +105,7 @@ class Synchroniser(object):
                     self._futures.remove_item(fut)
 
 
-def create_reader_and_writer(handler, *, loop=None):
-    if loop is None:
-        loop = asyncio.get_event_loop()
+def create_reader_and_writer(handler, *, loop):
     q = asyncio.Queue(loop=loop)
     reader = QueueReader(handler, q, loop=loop)
     writer = QueueWriter(q)


### PR DESCRIPTION
In my company we use 2 event loops in our project. To avoid errors we unset the global loop, so we know exactly what loop is used for futures and stuff. Libraries should respect this need.
This will also be of help for ppl, that use asyncio not in main Thread, where default loop is not set by policy.