### PR TITLE
Refactored Synchroniser to use simpler self._futures construct

### DIFF
--- a/src/asynqp/connection.py
+++ b/src/asynqp/connection.py
@@ -4,6 +4,7 @@ import sys
 from . import channel
 from . import spec
 from . import routing
+from .exceptions import AlreadyClosed
 
 log = logging.getLogger(__name__)
 
@@ -66,7 +67,10 @@ class Connection(object):
         if not self.closed.done():
             self._closing.set_result(True)
             self.sender.send_Close(0, 'Connection closed by application', 0, 0)
-            yield from self.synchroniser.await(spec.ConnectionCloseOK)
+            try:
+                yield from self.synchroniser.await(spec.ConnectionCloseOK)
+            except AlreadyClosed:
+                pass
             # Close heartbeat
             # TODO: We really need a better solution for finalization of parts
             #       in the library.

--- a/src/asynqp/exceptions.py
+++ b/src/asynqp/exceptions.py
@@ -11,7 +11,12 @@ __all__ = [
 __all__.extend(EXCEPTIONS.keys())
 
 
-class ConnectionLostError(ConnectionError):
+class AlreadyClosed(Exception):
+    """ Raised when issuing commands on closed Channel/Connection.
+    """
+
+
+class ConnectionLostError(AlreadyClosed, ConnectionError):
     '''
     Connection was closed unexpectedly
     '''

--- a/src/asynqp/log.py
+++ b/src/asynqp/log.py
@@ -1,0 +1,3 @@
+import logging
+
+log = logging.getLogger("asynqp")

--- a/src/asynqp/protocol.py
+++ b/src/asynqp/protocol.py
@@ -46,7 +46,12 @@ class AMQP(asyncio.Protocol):
         self.heartbeat_monitor.start(heartbeat_interval)
 
     def connection_lost(self, exc):
-        self.dispatcher.dispatch_all(frames.PoisonPillFrame(exc))
+        if exc is None:
+            poison_exc = ConnectionLostError(
+                'The connection was unexpectedly lost')
+        else:
+            poison_exc = exc
+        self.dispatcher.dispatch_all(frames.PoisonPillFrame(poison_exc))
         if exc is not None:
             raise ConnectionLostError('The connection was unexpectedly lost') from exc
 

--- a/src/asynqp/routing.py
+++ b/src/asynqp/routing.py
@@ -2,6 +2,7 @@ import asyncio
 import collections
 from . import frames
 from . import spec
+from .log import log
 
 
 _TEST = False
@@ -56,54 +57,48 @@ class Actor(object):
         meth(frame)
 
     def handle_PoisonPillFrame(self, frame):
-        self.synchroniser.killall(ConnectionError)
+        self.synchroniser.killall(frame.exception)
 
 
 class Synchroniser(object):
-    _blocking_methods = set((spec.BasicCancelOK,  # Consumer.cancel
-                             spec.ChannelCloseOK,  # Channel.close
-                             spec.ConnectionCloseOK))  # Connection.close
 
     def __init__(self, *, loop):
         self._loop = loop
-        self._futures = OrderedManyToManyMap()
-        self.connection_closed = False
+        self._futures = collections.defaultdict(collections.deque)
+        self.connection_exc = None
 
     def await(self, *expected_methods):
         fut = asyncio.Future(loop=self._loop)
 
-        if self.connection_closed:
-            for method in expected_methods:
-                if method in self._blocking_methods and not fut.done():
-                    fut.set_result(None)
-            if not fut.done():
-                fut.set_exception(ConnectionError)
+        if self.connection_exc is not None:
+            fut.set_exception(self.connection_exc)
             return fut
 
-        self._futures.add_item(expected_methods, fut)
+        for method in expected_methods:
+            self._futures[method].append((fut, expected_methods))
         return fut
 
     def notify(self, method, result=None):
-        fut = self._futures.get_leftmost(method)
-        fut.set_result(result)
-        self._futures.remove_item(fut)
+        try:
+            fut, bound_methods = self._futures[method].popleft()
+        except IndexError:
+            # XXX: we can't just ignore this.
+            log.error("Got an unexpected method notification %s", method)
+        else:
+            # Cleanup futures, that were awaited together, like
+            # (spec.BasicGetOK, spec.BasicGetEmpty)
+            for other_method in bound_methods:
+                if other_method != method:
+                    self._futures[other_method].remove((fut, bound_methods))
+            fut.set_result(result)
 
     def killall(self, exc):
-        self.connection_closed = True
-        # Give a proper notification to methods which are waiting for closure
-        for method in self._blocking_methods:
-            while True:
-                try:
-                    self.notify(method)
-                except StopIteration:
-                    break
-
+        self.connection_exc = exc
         # Set an exception for all others
-        for method in self._futures.keys():
-            if method not in self._blocking_methods:
-                for fut in self._futures.get_all(method):
-                    fut.set_exception(exc)
-                    self._futures.remove_item(fut)
+        for method, futs in self._futures.items():
+            for fut, _ in futs:
+                fut.set_exception(exc)
+        self._futures.clear()
 
 
 # When ready() is called, wait for a frame to arrive on the queue.
@@ -134,54 +129,3 @@ class QueuedReader(object):
             self._loop.call_soon(self.handler.handle, frame)
         else:
             self.pending_frames.append(frame)
-
-
-class OrderedManyToManyMap(object):
-    def __init__(self):
-        self._items = collections.defaultdict(OrderedSet)
-
-    def add_item(self, keys, item):
-        for key in keys:
-            self._items[key].add(item)
-
-    def remove_item(self, item):
-        for ordered_set in self._items.values():
-            ordered_set.discard(item)
-
-    def get_leftmost(self, key):
-        return self._items[key].first()
-
-    def get_all(self, key):
-        return list(self._items[key])
-
-    def keys(self):
-        return (k for k, v in self._items.items() if v)
-
-
-class OrderedSet(collections.MutableSet):
-    def __init__(self):
-        self._map = collections.OrderedDict()
-
-    def __contains__(self, item):
-        return item in self._map
-
-    def __iter__(self):
-        return iter(self._map.keys())
-
-    def __getitem__(self, ix):
-        return
-
-    def __len__(self):
-        return len(self._map)
-
-    def add(self, item):
-        self._map[item] = None
-
-    def discard(self, item):
-        try:
-            del self._map[item]
-        except KeyError:
-            pass
-
-    def first(self):
-        return next(iter(self))

--- a/test/queue_tests.py
+++ b/test/queue_tests.py
@@ -178,6 +178,19 @@ class WhenBasicGetOKArrives(QueueContext):
         assert self.task.result().routing_key == 'routing.key'
 
 
+class WhenConnectionClosedOnGet(QueueContext):
+    def given_I_asked_for_a_message(self):
+        self.task = asyncio.async(self.queue.get(no_ack=False))
+        self.tick()
+
+    def when_connection_is_closed(self):
+        self.server.protocol.connection_lost(None)
+        self.tick()
+
+    def it_should_raise_exception(self):
+        assert self.task.exception() is not None
+
+
 class WhenISubscribeToAQueue(QueueContext):
     def when_I_start_a_consumer(self):
         self.async_partial(self.queue.consume(lambda msg: None, no_local=False, no_ack=False, exclusive=False, arguments={'x-priority': 1}))


### PR DESCRIPTION
Will ease work on #34, as it remembers the exception, the synchroniser was killed with to raise them later.