### PR TITLE
Changed how protocol handles connection_lost. Don't dispatch PoisonPill.

### DIFF
--- a/src/asynqp/exceptions.py
+++ b/src/asynqp/exceptions.py
@@ -20,7 +20,10 @@ class ConnectionLostError(AlreadyClosed, ConnectionError):
     '''
     Connection was closed unexpectedly
     '''
-    pass
+
+    def __init__(self, message, exc=None):
+        super().__init__(message)
+        self.original_exc = exc
 
 
 class UndeliverableMessage(ValueError):

--- a/test/channel_tests.py
+++ b/test/channel_tests.py
@@ -231,3 +231,14 @@ class WhenTheHandlerIsNotCallable(OpenChannelContext):
 
     def it_should_throw_a_TypeError(self):
         assert isinstance(self.exception, TypeError)
+
+
+class WhenAConnectionIsLostCloseChannel(OpenChannelContext):
+    def when_connection_is_closed(self):
+        try:
+            self.connection.protocol.connection_lost(Exception())
+        except Exception:
+            pass
+
+    def it_should_not_hang(self):
+        self.loop.run_until_complete(asyncio.wait_for(self.channel.close(), 0.2))

--- a/test/connection_tests.py
+++ b/test/connection_tests.py
@@ -105,3 +105,14 @@ class WhenAConnectionThatWasClosedByTheServerReceivesAMethod(OpenConnectionConte
 
     def it_MUST_be_discarded(self):
         self.server.should_not_have_received_any()
+
+
+class WhenAConnectionIsLostCloseConnection(OpenConnectionContext):
+    def when_connection_is_closed(self):
+        try:
+            self.connection.protocol.connection_lost(Exception())
+        except Exception:
+            pass
+
+    def it_should_not_hang(self):
+        self.loop.run_until_complete(asyncio.wait_for(self.connection.close(), 0.2))


### PR DESCRIPTION
When we closed the connection on client-server handshake we close transport. The transport by asyncio docs calls ``connection_lost(None)``. Before this patch we dispatched a PoisonPill even if we closed everything already.