### PR TITLE
Refactored close procedures to dispatch Errors for all components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ doc/_build/
 
 *.sublime-workspace
 .ipynb_checkpoints
+.DS_Store

--- a/src/asynqp/__init__.py
+++ b/src/asynqp/__init__.py
@@ -69,7 +69,13 @@ def connect(host='localhost',
     if (sk.family in (socket.AF_INET, socket.AF_INET6)) and (sk.proto in (0, socket.IPPROTO_TCP)):
         sk.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
-    connection = yield from open_connection(loop, transport, protocol, dispatcher, {'username': username, 'password': password, 'virtual_host': virtual_host})
+    connection_info = {
+        'username': username,
+        'password': password,
+        'virtual_host': virtual_host
+    }
+    connection = yield from open_connection(
+        loop, transport, protocol, dispatcher, connection_info)
     return connection
 
 

--- a/src/asynqp/_exceptions.py
+++ b/src/asynqp/_exceptions.py
@@ -1,2 +1,6 @@
 class AMQPError(IOError):
     pass
+
+
+class AMQPChannelError(AMQPError):
+    pass

--- a/src/asynqp/channel.py
+++ b/src/asynqp/channel.py
@@ -9,8 +9,7 @@ from . import exchange
 from . import message
 from . import routing
 from .exceptions import (
-    UndeliverableMessage, ClientChannelClosed,
-    ServerConnectionClosed, ClientConnectionClosed, AMQPError)
+    UndeliverableMessage, AMQPError, ChannelClosed)
 from .log import log
 
 
@@ -42,7 +41,7 @@ class Channel(object):
         self.queue_factory = queue_factory
         self.reader = reader
         self._closed = False
-        # Indicates, that channel is closed or started closing
+        # Indicates, that channel is closing by client(!) call
         self._closing = False
 
     @asyncio.coroutine
@@ -330,7 +329,7 @@ class ChannelActor(routing.Actor):
         # Release the `close` method's future
         self.synchroniser.notify(spec.ChannelCloseOK)
 
-        exc = ClientChannelClosed()
+        exc = ChannelClosed()
         self._close_all(exc)
 
     def _close_all(self, exc):

--- a/src/asynqp/exceptions.py
+++ b/src/asynqp/exceptions.py
@@ -5,9 +5,8 @@ from .spec import EXCEPTIONS, CONSTANTS_INVERSE
 __all__ = [
     "AMQPError",
     "ConnectionLostError",
-    "ServerConnectionClosed",
-    "ClientChannelClosed",
-    "ClientConnectionClosed",
+    "ChannelClosed",
+    "ConnectionClosed",
     "AMQPChannelError",
     "AMQPConnectionError",
     "UndeliverableMessage",
@@ -28,21 +27,17 @@ class ConnectionLostError(AMQPConnectionError, ConnectionError):
         self.original_exc = exc
 
 
-class ClientConnectionClosed(AMQPConnectionError):
+class ConnectionClosed(AMQPConnectionError):
     """ Connection was closed by client """
 
-
-class ClientChannelClosed(AMQPChannelError):
-    """ Channel was closed by client """
-
-
-class ServerConnectionClosed(AMQPConnectionError):
-    """ Connection was closed by server """
-
-    def __init__(self, reply_text, reply_code):
+    def __init__(self, reply_text, reply_code=None):
         super().__init__(reply_text)
         self.reply_text = reply_text
         self.reply_code = reply_code
+
+
+class ChannelClosed(AMQPChannelError):
+    """ Channel was closed by client """
 
 
 class UndeliverableMessage(ValueError):

--- a/src/asynqp/exceptions.py
+++ b/src/asynqp/exceptions.py
@@ -1,29 +1,43 @@
-from ._exceptions import AMQPError
+from ._exceptions import AMQPError, AMQPChannelError
 from .spec import EXCEPTIONS, CONSTANTS_INVERSE
 
 
 __all__ = [
     "AMQPError",
     "ConnectionLostError",
+    "ServerConnectionClosed",
+    "ClientChannelClosed",
+    "ClientConnectionClosed",
+    "AMQPChannelError",
+    "AMQPConnectionError",
     "UndeliverableMessage",
     "Deleted"
 ]
 __all__.extend(EXCEPTIONS.keys())
 
 
-class AlreadyClosed(Exception):
-    """ Raised when issuing commands on closed Channel/Connection.
-    """
+class AMQPConnectionError(AMQPError):
+    pass
 
 
-class ConnectionLostError(AlreadyClosed, ConnectionError):
-    '''
-    Connection was closed unexpectedly
-    '''
+class ConnectionLostError(AMQPConnectionError, ConnectionError):
+    """ Connection was closed unexpectedly """
 
     def __init__(self, message, exc=None):
         super().__init__(message)
         self.original_exc = exc
+
+
+class ClientConnectionClosed(AMQPConnectionError):
+    """ Connection was closed by client """
+
+
+class ClientChannelClosed(AMQPChannelError):
+    """ Channel was closed by client """
+
+
+class ServerConnectionClosed(AMQPConnectionError):
+    """ Connection was closed by server """
 
 
 class UndeliverableMessage(ValueError):

--- a/src/asynqp/exceptions.py
+++ b/src/asynqp/exceptions.py
@@ -39,6 +39,11 @@ class ClientChannelClosed(AMQPChannelError):
 class ServerConnectionClosed(AMQPConnectionError):
     """ Connection was closed by server """
 
+    def __init__(self, reply_text, reply_code):
+        super().__init__(reply_text)
+        self.reply_text = reply_text
+        self.reply_code = reply_code
+
 
 class UndeliverableMessage(ValueError):
     pass

--- a/src/asynqp/protocol.py
+++ b/src/asynqp/protocol.py
@@ -8,6 +8,7 @@ from .log import log
 
 class AMQP(asyncio.Protocol):
     def __init__(self, dispatcher, loop):
+        self._loop = loop
         self.dispatcher = dispatcher
         self.partial_frame = b''
         self.frame_reader = FrameReader()
@@ -139,6 +140,8 @@ class HeartbeatMonitor(object):
 
     @asyncio.coroutine
     def send_heartbeat(self, interval):
+        # XXX: Add `last_sent` frame monitoring to not send heartbeats
+        #      if traffic was going through socket
         while True:
             self.protocol.send_frame(frames.HeartbeatFrame())
             yield from asyncio.sleep(interval, loop=self.loop)

--- a/src/asynqp/protocol.py
+++ b/src/asynqp/protocol.py
@@ -8,7 +8,6 @@ from .log import log
 
 class AMQP(asyncio.Protocol):
     def __init__(self, dispatcher, loop):
-        self._loop = loop
         self.dispatcher = dispatcher
         self.partial_frame = b''
         self.frame_reader = FrameReader()

--- a/src/asynqp/queue.py
+++ b/src/asynqp/queue.py
@@ -2,7 +2,7 @@ import asyncio
 import re
 from operator import delitem
 from . import spec
-from .exceptions import Deleted, AlreadyClosed
+from .exceptions import Deleted, AMQPError
 
 
 VALID_QUEUE_NAME_RE = re.compile(r'^(?!amq\.)(\w|[-.:])*$', flags=re.A)
@@ -257,10 +257,10 @@ class Consumer(object):
 
         This method is a :ref:`coroutine <coroutine>`.
         """
-        self.sender.send_BasicCancel(self.tag)
         try:
+            self.sender.send_BasicCancel(self.tag)
             yield from self.synchroniser.await(spec.BasicCancelOK)
-        except AlreadyClosed:
+        except AMQPError:
             pass
         else:
             # No need to call ready if connection closed.

--- a/src/asynqp/queue.py
+++ b/src/asynqp/queue.py
@@ -257,13 +257,13 @@ class Consumer(object):
 
         This method is a :ref:`coroutine <coroutine>`.
         """
+        self.sender.send_BasicCancel(self.tag)
         try:
-            self.sender.send_BasicCancel(self.tag)
             yield from self.synchroniser.await(spec.BasicCancelOK)
         except AMQPError:
             pass
         else:
-            # No need to call ready if connection closed.
+            # No need to call ready if channel closed.
             self.reader.ready()
         self.cancelled = True
         self.cancelled_future.set_result(self)

--- a/src/asynqp/routing.py
+++ b/src/asynqp/routing.py
@@ -5,9 +5,6 @@ from . import spec
 from .log import log
 
 
-_TEST = False
-
-
 class Dispatcher(object):
     def __init__(self):
         self.handlers = {}
@@ -21,8 +18,15 @@ class Dispatcher(object):
     def dispatch(self, frame):
         if isinstance(frame, frames.HeartbeatFrame):
             return
-        handler = self.handlers[frame.channel_id]
-        handler(frame)
+        # XXX: Could not find a better way to close channels...
+        elif isinstance(frame.payload, (spec.ConnectionCloseOK,
+                                        spec.ConnectionClose)):
+            # Notify all connection channels about it
+            for handler in self.handlers.values():
+                handler(frame)
+        else:
+            handler = self.handlers[frame.channel_id]
+            handler(frame)
 
     def dispatch_all(self, frame):
         for handler in self.handlers.values():
@@ -33,9 +37,18 @@ class Sender(object):
     def __init__(self, channel_id, protocol):
         self.channel_id = channel_id
         self.protocol = protocol
+        self.connection_exc = None
 
     def send_method(self, method):
+        if self.connection_exc is not None:
+            raise self.connection_exc
         self.protocol.send_method(self.channel_id, method)
+
+    def killall(self, exc):
+        """ Connection/Channel was closed. All subsequent requests should
+            raise an error
+        """
+        self._connection_exc = exc
 
 
 class Actor(object):
@@ -43,21 +56,14 @@ class Actor(object):
         self._loop = loop
         self.synchroniser = synchroniser
         self.sender = sender
-        self.closing = asyncio.Future(loop=self._loop)
 
     def handle(self, frame):
-        close_methods = (spec.ConnectionClose, spec.ConnectionCloseOK, spec.ChannelClose, spec.ChannelCloseOK)
-        if self.closing.done() and not isinstance(frame.payload, close_methods):
-            return
         try:
             meth = getattr(self, 'handle_' + type(frame).__name__)
         except AttributeError:
             meth = getattr(self, 'handle_' + type(frame.payload).__name__)
 
         meth(frame)
-
-    def handle_PoisonPillFrame(self, frame):
-        self.synchroniser.killall(frame.exception)
 
 
 class Synchroniser(object):
@@ -94,6 +100,9 @@ class Synchroniser(object):
         fut.set_result(result)
 
     def killall(self, exc):
+        """ Connection/Channel was closed. All subsequent and ongoing requests
+            should raise an error
+        """
         self.connection_exc = exc
         # Set an exception for all others
         for method, futs in self._futures.items():

--- a/test/base_contexts.py
+++ b/test/base_contexts.py
@@ -14,15 +14,9 @@ class LoopContext:
         self.exceptions = []
         self.loop = asyncio.get_event_loop()
         self.loop.set_debug(True)
-        self.loop.set_exception_handler(self.exception_handler)
-        asynqp.routing._TEST = True
 
     def cleanup_test_hack(self):
         self.loop.set_debug(False)
-        self.loop.set_exception_handler(None)
-        asynqp.routing._TEST = False
-        if self.exceptions:
-            raise self.exceptions[0]
 
     def exception_handler(self, loop, context):
         self.exceptions.append(context['exception'])
@@ -84,7 +78,7 @@ class OpenChannelContext(OpenConnectionContext):
         task = asyncio.async(self.connection.open_channel(), loop=self.loop)
         self.tick()
         self.server.send_method(channel_id, spec.ChannelOpenOK(''))
-        return task.result()
+        return self.loop.run_until_complete(task)
 
 
 class QueueContext(OpenChannelContext):

--- a/test/channel_tests.py
+++ b/test/channel_tests.py
@@ -240,7 +240,7 @@ class WhenAConnectionIsLostCloseChannel(OpenChannelContext):
         except Exception:
             pass
         self.tick()
-        self.was_closed = self.channel._closing
+        self.was_closed = self.channel.is_closed()
 
     def it_should_not_hang(self):
         self.loop.run_until_complete(asyncio.wait_for(self.channel.close(), 0.2))
@@ -254,7 +254,7 @@ class WhenWeCloseConnectionChannelShouldAlsoClose(OpenChannelContext):
         self.task = asyncio.async(self.connection.close(), loop=self.loop)
         self.server.send_method(0, spec.ConnectionCloseOK())
         self.tick()
-        self.was_closed = self.channel._closing
+        self.was_closed = self.channel.is_closed()
         self.loop.run_until_complete(asyncio.wait_for(self.task, 0.2))
 
     def it_should_not_hang_channel_close(self):
@@ -269,7 +269,7 @@ class WhenServerClosesConnectionChannelShouldAlsoClose(OpenChannelContext):
         self.server.send_method(
             0, spec.ConnectionClose(123, 'you muffed up', 10, 20))
         self.tick()
-        self.was_closed = self.channel._closing
+        self.was_closed = self.channel.is_closed()
 
     def it_should_not_hang_channel_close(self):
         self.loop.run_until_complete(asyncio.wait_for(self.channel.close(), 0.2))
@@ -291,7 +291,7 @@ class WhenServerAndClientCloseChannelAtATime(OpenChannelContext):
         self.task.result()
 
     def if_should_have_closed_channel(self):
-        assert self.channel._closing
+        assert self.channel.is_closed()
 
     def it_should_have_killed_synchroniser_with_404(self):
         assert self.channel.synchroniser.connection_exc == exceptions.NotFound

--- a/test/connection_tests.py
+++ b/test/connection_tests.py
@@ -147,7 +147,7 @@ class WhenOpeningAChannelOnAClosedConnection(OpenConnectionContext):
 
     def it_should_raise_error_in_connection_methods(self):
         exc = contexts.catch(self.wait_for, self.connection.open_channel())
-        assert isinstance(exc, exceptions.ClientConnectionClosed)
+        assert isinstance(exc, exceptions.ConnectionClosed)
 
 
 class WhenServerAndClientCloseConnectionAtATime(OpenConnectionContext):
@@ -168,4 +168,5 @@ class WhenServerAndClientCloseConnectionAtATime(OpenConnectionContext):
     def it_should_have_killed_synchroniser_with_server_error(self):
         assert isinstance(
             self.connection.synchroniser.connection_exc,
-            exceptions.ServerConnectionClosed)
+            exceptions.ConnectionClosed)
+        assert self.connection.synchroniser.connection_exc.reply_code == 123

--- a/test/integration_tests.py
+++ b/test/integration_tests.py
@@ -3,7 +3,6 @@ import asynqp
 import socket
 import contexts
 from asyncio import test_utils
-from unittest import mock
 
 
 class ConnectionContext:

--- a/test/integration_tests.py
+++ b/test/integration_tests.py
@@ -304,13 +304,3 @@ class WhenConsumingWithUnsetLoop:
             yield from self.connection.close()
         self.loop.run_until_complete(tear_down())
         asyncio.set_event_loop(self.loop)
-
-
-class WhenAConnectionClosedByHandshakeProtocolShouldNotDispatchPoisonPill(ConnectionContext):
-    def when_we_close_connection(self):
-        with mock.patch("asynqp.routing.Dispatcher.dispatch_all") as mocked:
-            self.loop.run_until_complete(self.connection.close())
-        self.mocked = mocked
-
-    def it_should_not_dispatch_poison(self):
-        assert not self.mocked.called


### PR DESCRIPTION
Basically now it will always raise appropriate exceptions for any public calls after closure. Added ClientClosed and ServerClosed exceptions. Maybe they are a little to grained, your thoughts?

Now we can write:
```python
@asyncio.coroutine
def do_stuff(connection):
    queue = yield from declare_queue(connection)
    consumer = yield from queue.consume(lambda x: print(x), no_ack=True)
    yield from asyncio.sleep(1)
    queue.publish(some_message)

connection = yield from connect()
while True:
    try:
        yield from consume(connection)
    except asynqp.exceptions.AlreadyClosed:
        connection = yield from reconnect()
```
and it will raise no matter where connection is lost.

Depends on #54. Please review that firts. I kinda split them in a way )