### PR TITLE
Remove QueuedReader and fix method cancellation

### DIFF
--- a/src/asynqp/exchange.py
+++ b/src/asynqp/exchange.py
@@ -22,8 +22,7 @@ class Exchange(object):
 
         the type of the exchange (usually one of ``'fanout'``, ``'direct'``, ``'topic'``, or ``'headers'``).
     """
-    def __init__(self, reader, synchroniser, sender, name, type, durable, auto_delete, internal):
-        self.reader = reader
+    def __init__(self, synchroniser, sender, name, type, durable, auto_delete, internal):
         self.synchroniser = synchroniser
         self.sender = sender
         self.name = name
@@ -53,4 +52,3 @@ class Exchange(object):
         """
         self.sender.send_ExchangeDelete(self.name, if_unused)
         yield from self.synchroniser.await(spec.ExchangeDeleteOK)
-        self.reader.ready()

--- a/src/asynqp/routing.py
+++ b/src/asynqp/routing.py
@@ -65,7 +65,8 @@ class Synchroniser(object):
 
         for method in expected_methods:
             self._futures[method].append(fut)
-        return fut
+
+        return asyncio.shield(fut, loop=self._loop)
 
     def notify(self, method, result=None):
         while True:

--- a/test/queue_tests.py
+++ b/test/queue_tests.py
@@ -501,52 +501,46 @@ class WhenConsumingWithGetOnQueueAndCancelTask(QueueContext):
     def it_should_not_set_msg(self):
         assert self.msg is self._default
 
-    def it_should_not_block_close(self):
-        self.loop.run_until_complete(
-            asyncio.wait_for(self.channel.close(), 0.2))
-        self.loop.run_until_complete(
-            asyncio.wait_for(self.connection.close(), 0.2))
 
+class WhenGettingInParallelAndCancelTask(QueueContext):
+    def given_i_use_BasicGet_in_2_tasks(self):
+        self.coro1 = asyncio.async(self._consumer(), loop=self.loop)
+        self.coro2 = asyncio.async(self._consumer(), loop=self.loop)
+        self.tick()
 
-# class WhenGettingInParallelAndCancelTask(QueueContext):
-#     def given_i_use_BasicGet_in_2_tasks(self):
-#         self.coro1 = asyncio.async(self._consumer(), loop=self.loop)
-#         self.coro2 = asyncio.async(self._consumer(), loop=self.loop)
-#         self.tick()
+    @asyncio.coroutine
+    def _consumer(self):
+        return (yield from self.queue.get())
 
-#     @asyncio.coroutine
-#     def _consumer(self):
-#         return (yield from self.queue.get())
+    def when_I_cancel_one_of_tasks(self):
+        self.coro1.cancel()
+        self.tick()
+        # Must be ignored for coro1
+        self.server.send_method(self.channel.id, spec.BasicGetEmpty(''))
+        # Must be delivered to coro2
+        self.expected_message = asynqp.Message(
+            'body', timestamp=datetime(2014, 5, 5))
+        self.server.send_method(self.channel.id, spec.BasicGetOK(
+            123, False, 'my.exchange', 'routing.key', 0))
+        header = message.get_header_payload(
+            self.expected_message, spec.BasicGet.method_type[0])
+        self.server.send_frame(
+            frames.ContentHeaderFrame(self.channel.id, header))
+        body = message.get_frame_payloads(self.expected_message, 100)[0]
+        self.server.send_frame(frames.ContentBodyFrame(self.channel.id, body))
+        self.tick()
+        self.tick()
 
-#     def when_I_cancel_one_of_tasks(self):
-#         self.coro1.cancel()
-#         self.tick()
-#         # Must be ignored for coro1
-#         self.server.send_method(self.channel.id, spec.BasicGetEmpty(''))
-#         # Must be delivered to coro2
-#         self.expected_message = asynqp.Message(
-#             'body', timestamp=datetime(2014, 5, 5))
-#         self.server.send_method(self.channel.id, spec.BasicGetOK(
-#             123, False, 'my.exchange', 'routing.key', 0))
-#         header = message.get_header_payload(
-#             self.expected_message, spec.BasicGet.method_type[0])
-#         self.server.send_frame(
-#             frames.ContentHeaderFrame(self.channel.id, header))
-#         body = message.get_frame_payloads(self.expected_message, 100)[0]
-#         self.server.send_frame(frames.ContentBodyFrame(self.channel.id, body))
-#         self.tick()
-#         self.tick()
+    def it_should_stop_coro1(self):
+        assert self.coro1.cancelled()
+        try:
+            self.loop.run_until_complete(
+                asyncio.wait_for(self.coro1, 0.2))
+        except asyncio.CancelledError:
+            pass
 
-#     def it_should_stop_coro1(self):
-#         assert self.coro1.cancelled()
-#         try:
-#             self.loop.run_until_complete(
-#                 asyncio.wait_for(self.coro1, 0.2))
-#         except asyncio.CancelledError:
-#             pass
-
-#     def it_should_deliver_message_to_coro2(self):
-#         assert self.coro2.result() is not None
-#         assert self.coro2.result() == self.expected_message
-#         assert self.coro2.result().exchange_name == 'my.exchange'
-#         assert self.coro2.result().routing_key == 'routing.key'
+    def it_should_deliver_message_to_coro2(self):
+        assert self.coro2.result() is not None
+        assert self.coro2.result() == self.expected_message
+        assert self.coro2.result().exchange_name == 'my.exchange'
+        assert self.coro2.result().routing_key == 'routing.key'


### PR DESCRIPTION
As I stated in #52 fixing the cancellation issue without removing `reader` is too hard.
I've gone through the code base. The `Reader` is responsible for synchronous consumption of frames, but there is No need for that if we just maintain the code correctly:

* `Synchroniser.await` should be called right after `sender.send_*` method. At least it should not contain `yield from` calls in between.

In `asyncio` we already have the loop, which has a great scheduling machinery, that will guaranty sequential call order. 