### PR TITLE
Mark amq.rabbitmq.reply-to as valid queue name

### DIFF
--- a/src/asynqp/channel.py
+++ b/src/asynqp/channel.py
@@ -13,7 +13,6 @@ from .exceptions import (
 from .log import log
 
 
-VALID_QUEUE_NAME_RE = re.compile(r'^(?!amq\.)(\w|[-.:])*$', flags=re.A)
 VALID_EXCHANGE_NAME_RE = re.compile(r'^(?!amq\.)(\w|[-.:])+$', flags=re.A)
 
 

--- a/src/asynqp/queue.py
+++ b/src/asynqp/queue.py
@@ -283,7 +283,7 @@ class QueueFactory(object):
     @asyncio.coroutine
     def declare(self, name, durable, exclusive, auto_delete, passive, nowait,
                 arguments):
-        if not VALID_QUEUE_NAME_RE.match(name):
+        if not (name == 'amq.rabbitmq.reply-to' or VALID_QUEUE_NAME_RE.match(name)):
             raise ValueError(
                 "Not a valid queue name.\n"
                 "Valid names consist of letters, digits, hyphen, underscore, "


### PR DESCRIPTION
Hey!

RabbitMQ has special queue with name 'amq.rabbitmq.reply-to', it is described in https://www.rabbitmq.com/direct-reply-to.html