### PR TITLE
Doc mandatory param; cross link to set_return_handler

### DIFF
--- a/src/asynqp/exchange.py
+++ b/src/asynqp/exchange.py
@@ -38,6 +38,7 @@ class Exchange(object):
 
         :param asynqp.Message message: the message to send
         :param str routing_key: the routing key with which to publish the message
+        :param bool mandatory: if True (the default) undeliverable messages result in an error (see also :meth:`Channel.set_return_handler`)
         """
         self.sender.send_BasicPublish(self.name, routing_key, mandatory, message)
 


### PR DESCRIPTION
I spent a while digging around in the source before I found that one gets to handle unpublishable messages by setting a return handler on the channel.  A link from publish to that method would have saved me a lot of time :)